### PR TITLE
Merge pull request #14 from ox-it/WL-3756

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5898,7 +5898,7 @@ public class AssignmentAction extends PagedResourceActionII
 
 							// clean the ContentReview attributes
 							sEdit.setReviewIconUrl(null);
-							sEdit.setReviewScore(0); // default to be 0?
+							sEdit.setReviewScore(-2); // the default is -2 (e.g., for a new submission)
 							sEdit.setReviewStatus(null);
 
 							if (StringUtils.trimToNull(sEdit.getFeedbackFormattedText()) != null)


### PR DESCRIPTION
WL-3756: Make the default review score for a re-submission the same as for a new submission. The default review score for a new submission is -2, not 0.
